### PR TITLE
Check only the cinder uuid

### DIFF
--- a/sensu/plugins/check-cinder-sessions.py
+++ b/sensu/plugins/check-cinder-sessions.py
@@ -60,7 +60,7 @@ def _get_active_iscsi_volumes():
         out = subprocess.check_output(['iscsiadm', '-m', 'session'])
         for line in out.strip().split('\n'):
             parts = line.split(':')
-            volumes.add(parts[-1][7:])  # remove 'volume-'
+            volumes.add(parts[-1][7:43])  # remove 'volume-'
     except Exception, e:
         # iscsiadm returns 21 if there are no active sessions.
         if e.returncode == 21:


### PR DESCRIPTION
This check assumed that the format presented by iscsiadm was simply
volume-<uuid>. There are scenarios however where the uuid has
additional data tacked on the end. This was yielding false positives,
so make sure we only capture the UUID.
