### PR TITLE
cinder-session-show-vm: show vm

### DIFF
--- a/sensu/plugins/check-cinder-sessions.py
+++ b/sensu/plugins/check-cinder-sessions.py
@@ -78,11 +78,11 @@ def main():
 
         for vm_and_vols in expected_vols:
             if not vm_and_vols[1][0]['id'] in connected_vols:
-                print "The instance %s has the volume %s attached, " \
+                print("The instance %s has the volume %s attached, " \
                       "but that volume does not have an iscsi session" \
-                      % (vm_and_vols[0], vm_and_vols[1][0]['id'],)
+                      % (vm_and_vols[0], vm_and_vols[1][0]['id'],))
     except Exception as e:
-        print "Could not run check: %s" % e
+        print("Could not run check: %s" % e)
         sys.exit(2)
     sys.exit(failure)
 

--- a/sensu/plugins/check-cinder-sessions.py
+++ b/sensu/plugins/check-cinder-sessions.py
@@ -50,7 +50,7 @@ def _get_local_active_instance_volumes():
         attached_vols = \
             getattr(server, 'os-extended-volumes:volumes_attached')
         if server_hv == hostname and len(attached_vols):
-            local_attached_vols += attached_vols
+            local_attached_vols.append([ getattr(server, 'id'), attached_vols ])
     return local_attached_vols
 
 
@@ -76,11 +76,11 @@ def main():
         expected_vols = _get_local_active_instance_volumes()
         connected_vols = _get_active_iscsi_volumes()
 
-        for vol in expected_vols:
-            if not vol['id'] in connected_vols:
-                print "Volume %s is 'in-use' but not " \
-                      "connected" % vol['id']
-                failure = True
+        for vm_and_vols in expected_vols:
+            if not vm_and_vols[1][0]['id'] in connected_vols:
+                print "The instance %s has the volume %s attached, " \
+                      "but that volume does not have an iscsi session" \
+                      % (vm_and_vols[0], vm_and_vols[1][0]['id'],)
     except Exception as e:
         print "Could not run check: %s" % e
         sys.exit(2)


### PR DESCRIPTION
1) When a cinder session is found to be invalid we should tell the operator which VM is attached to the volume.  
2) Be more clear in the error message and say that no matching iscsi sessions were found.
