### PR TITLE
move to sensu embedded ruby

### DIFF
--- a/sensu/plugins/check-netif.rb
+++ b/sensu/plugins/check-netif.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/opt/sensu/embedded/bin/ruby
 #
 #   netif-metrics
 #


### PR DESCRIPTION
moving this check to sensu embedded ruby, as it failed on a dedicated cinder node
