### PR TITLE
check-glance-store: don't check remote images

### DIFF
--- a/sensu/plugins/check-glance-store.py
+++ b/sensu/plugins/check-glance-store.py
@@ -17,7 +17,7 @@ from keystoneclient.v2_0 import client as ksclient
 
 def is_remote_image(image):
     if image.get('location'):
-        http_re = re.compile(r'^https?://')
+        http_re = re.compile(r'^(http|https|ftp)://')
         return http_re.match(image.location)
     return False
 

--- a/sensu/plugins/check-glance-store.py
+++ b/sensu/plugins/check-glance-store.py
@@ -15,6 +15,11 @@ from glanceclient import client
 from iso8601 import iso8601
 from keystoneclient.v2_0 import client as ksclient
 
+def is_remote_image(image):
+    if image.get('location'):
+        http_re = re.compile(r'^https?://')
+        return http_re.match(image.location)
+    return False
 
 glance_auth = {
     'username':    os.environ['OS_USERNAME'],
@@ -64,7 +69,7 @@ kwargs = {'sort_key': 'id', 'sort_dir': 'asc', 'owner': None, 'filters': {}, 'is
 for x in glance.images.list(**kwargs):
     if x.status == 'active':
         tz_aware_time = parser.parse(x.created_at)
-        glance_images.append((x.id, x.size, tz_aware_time))
+        glance_images.append((x.id, x.size, tz_aware_time, is_remote_image(x)))
 
 # Check all active images 1 hour or older are present
 time_cutoff = datetime.now(iso8601.Utc()) - timedelta(0, 3600)
@@ -73,9 +78,9 @@ result = 0
 
 for image in [x for x in glance_images if x[2] < time_cutoff]:
     if not [x for x in files if x[0] == image[0]]:
-        print "Glance image %s not found in %s" % (image[0], store_directory)
-        result = 2
-
+        if image[3] == False:
+            print "Glance image %s not found in %s" % (image[0], store_directory)
+            result = 2
 
 # Check all files have a corresponding glance image
 for image_file in files:


### PR DESCRIPTION
If a glance image has a location with a url in it then the check shouldn't be surprised if there is not a associated file in the file store.
