### PR TITLE
check-for-large-files: default to 1GB, list files

### DIFF
--- a/sensu/plugins/check-for-large-files.sh
+++ b/sensu/plugins/check-for-large-files.sh
@@ -35,9 +35,10 @@ fi
 WARN=${WARN:=3}
 CRIT=${CRIT:=10}
 DIR=${DIR:=/var/log}
-SIZE=${SIZE:=1048576}
+SIZE=${SIZE:=1024M}
 
-NUM_FILES=`find ${DIR} -type f -size +${SIZE} | wc -l`
+FILES=$(find ${DIR} -type f -size +${SIZE})
+NUM_FILES=$(echo "$FILES" | wc -l)
 
 if (( $NUM_FILES == 1)); then
   FILE=file
@@ -45,7 +46,8 @@ else
   FILE=files
 fi
 
-output="$NUM_FILES $FILE bigger than ${SIZE} in ${DIR}"
+output="$NUM_FILES $FILE bigger than ${SIZE} in ${DIR}
+${FILES}"
 
 if (( $NUM_FILES >= $CRIT )); then
   echo "CRITICAL - $output"


### PR DESCRIPTION
Getting paged for files larger than 1048576 512-byte blocks (512MB) is confusing. Let's be less confusing. Let's also default to 1GB, which is when lots of logrotate is configured to roll logs.

Let's also show exactly which files are too large in the check output so the check is actionable.

Example:

```
# ./check-for-large-files.sh
CRITICAL - 10 files bigger than 1024M in /var/log
/var/log/neutron/neutron-linuxbridge-agent.log
/var/log/neutron/neutron-linuxbridge-agent.log.4.gz
/var/log/neutron/neutron-linuxbridge-agent.log.1.gz
/var/log/neutron/neutron-linuxbridge-agent.log.2.gz
/var/log/neutron/neutron-linuxbridge-agent.log.3.gz
/var/log/upstart/neutron-linuxbridge-agent.log
/var/log/upstart/neutron-linuxbridge-agent.log.4.gz
/var/log/upstart/neutron-linuxbridge-agent.log.1.gz
/var/log/upstart/neutron-linuxbridge-agent.log.2.gz
/var/log/upstart/neutron-linuxbridge-agent.log.3.gz
```
