### PR TITLE
check-for-large-files: ignore empty lines in count

### DIFF
--- a/sensu/plugins/check-for-large-files.sh
+++ b/sensu/plugins/check-for-large-files.sh
@@ -38,7 +38,7 @@ DIR=${DIR:=/var/log}
 SIZE=${SIZE:=1024M}
 
 FILES=$(find ${DIR} -type f -size +${SIZE})
-NUM_FILES=$(echo "$FILES" | wc -l)
+NUM_FILES=$(echo "$FILES" | grep -v '^$' | wc -l)
 
 if (( $NUM_FILES == 1)); then
   FILE=file


### PR DESCRIPTION
Missed an off-by-1 error I introduced in #38. This fixes it.
