### PR TITLE
Remove referneces to novaclient 1.1

### DIFF
--- a/sensu/plugins/check-cinder-sessions.py
+++ b/sensu/plugins/check-cinder-sessions.py
@@ -19,7 +19,7 @@ import os
 import subprocess
 import sys
 
-from novaclient.v1_1.client import Client as nova_client
+from novaclient.client import Client as nova_client
 
 CREDS = {
     'username': os.environ['OS_USERNAME'],
@@ -38,7 +38,7 @@ def _get_local_active_instance_volumes():
     hostname = _get_hostname()
 
     local_attached_vols = []
-    nova = nova_client(**CREDS)
+    nova = nova_client(version=2, **CREDS)
     search_opts = {
         'all_tenants': True
     }

--- a/sensu/plugins/metrics-nova-state.py
+++ b/sensu/plugins/metrics-nova-state.py
@@ -6,7 +6,7 @@ import socket
 import time
 import os
 
-from novaclient.v1_1 import Client
+from novaclient.client import Client
 
 DEFAULT_SCHEME = '{}.nova.states'.format(socket.gethostname())
 
@@ -23,7 +23,9 @@ def main():
     parser.add_argument('-s', '--scheme', default=DEFAULT_SCHEME)
     args = parser.parse_args()
 
-    client = Client(args.user, args.password, args.tenant, args.auth_url, service_type=args.service_type)
+    client = Client(version=2, username=args.user, api_key=args.password,
+                    project_id=args.tenant, auth_url=args.auth_url,
+                    service_type=args.service_type)
 
     servers = client.servers.list()
 

--- a/sensu/plugins/metrics-nova.py
+++ b/sensu/plugins/metrics-nova.py
@@ -11,7 +11,7 @@ import socket
 import time
 import os
 
-from novaclient.v1_1 import Client
+from novaclient.client import Client
 
 DEFAULT_SCHEME = '{}.nova.hypervisors'.format(socket.gethostname())
 
@@ -43,7 +43,9 @@ def main():
 
     args.user
 
-    client = Client(args.user, args.password, args.tenant, args.auth_url, service_type=args.service_type)
+    client = Client(version=2, username=args.user, api_key=args.password,
+                    project_id=args.tenant, auth_url=args.auth_url,
+                    service_type=args.service_type)
 
     if args.host:
         hypervisors = client.hypervisors.search(args.host)


### PR DESCRIPTION
1.1 is out, everything goes through v2 now, and later versions of
python-novaclient do not have the v1_1 class anymore. All access should
be through the client module and API version can be specified when
creating the client object via the Client class.
