### PR TITLE
Add flag to collect from all network interfaces

### DIFF
--- a/sensu/plugins/metrics-net.rb
+++ b/sensu/plugins/metrics-net.rb
@@ -39,7 +39,7 @@
 # Use the data with graphite's `nonNegativeDerivative()` function
 # to construct per-second graphs for your hosts.
 #
-# Loopback iface (`lo`) is ignored.
+# All ifaces not `eth` and `bond` are ignored by default.
 #
 # Compat
 # ------
@@ -73,6 +73,11 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-s SCHEME',
          long: '--scheme SCHEME',
          default: "#{Socket.gethostname}.net"
+  option :all,
+         description: 'Return results for all interfaces, not just eth and bond',
+         short: '-a',
+         long: '--all',
+         default: false
 
   def run
     timestamp = Time.now.to_i
@@ -80,7 +85,7 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
     Dir.glob('/sys/class/net/*').each do |iface_path|
       next if File.file?(iface_path)
       iface = File.basename(iface_path)
-      next if iface == 'lo'
+      next if !config[:all] and !iface.include?('eth') and !iface.include?('bond')
 
       tx_pkts = File.open(iface_path + '/statistics/tx_packets').read.strip
       rx_pkts = File.open(iface_path + '/statistics/rx_packets').read.strip

--- a/sensu/plugins/metrics-net.rb
+++ b/sensu/plugins/metrics-net.rb
@@ -39,7 +39,7 @@
 # Use the data with graphite's `nonNegativeDerivative()` function
 # to construct per-second graphs for your hosts.
 #
-# All ifaces not `eth` and `bond` are ignored by default.
+# Non `eth` and `bond` ifaces are ignored by default.
 #
 # Compat
 # ------
@@ -52,7 +52,7 @@
 # Example:
 # --------
 #
-# $ ./metrics-packets.rb --scheme servers.web01
+# $ ./metrics-packets.rb --scheme servers.web01 -i eth
 #   servers.web01.eth0.tx_packets 982965    1351112745
 #   servers.web01.eth0.rx_packets 1180186   1351112745
 #   servers.web01.eth1.tx_packets 273936669 1351112745
@@ -74,18 +74,25 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--scheme SCHEME',
          default: "#{Socket.gethostname}.net"
   option :all,
-         description: 'Return results for all interfaces, not just eth and bond',
+         description: 'Return results for all interfaces',
          short: '-a',
          long: '--all',
          default: false
+  option :accept_ifaces,
+         description: 'List of interfaces to collect from (default eth,bond)',
+         short: '-i IFACE1,IFACE2,...',
+         long: '--interfaces IFACE1,IFACE2,...',
+         default: 'eth,bond'
 
   def run
     timestamp = Time.now.to_i
 
     Dir.glob('/sys/class/net/*').each do |iface_path|
       next if File.file?(iface_path)
-      iface = File.basename(iface_path)
-      next if !config[:all] and !iface.include?('eth') and !iface.include?('bond')
+      current_iface = File.basename(iface_path)
+      accept_ifaces = config[:accept_ifaces].split(',')
+      next if current_iface == 'lo'
+      next if !config[:all] and !accept_ifaces.any? { |accept_iface| current_iface.start_with?(accept_iface) }
 
       tx_pkts = File.open(iface_path + '/statistics/tx_packets').read.strip
       rx_pkts = File.open(iface_path + '/statistics/rx_packets').read.strip
@@ -95,14 +102,14 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
       rx_errors = File.open(iface_path + '/statistics/rx_errors').read.strip
       tx_dropped = File.open(iface_path + '/statistics/tx_dropped').read.strip
       rx_dropped = File.open(iface_path + '/statistics/rx_dropped').read.strip
-      output "#{config[:scheme]}.#{iface}.tx_packets", tx_pkts, timestamp
-      output "#{config[:scheme]}.#{iface}.rx_packets", rx_pkts, timestamp
-      output "#{config[:scheme]}.#{iface}.tx_bytes", tx_bytes, timestamp
-      output "#{config[:scheme]}.#{iface}.rx_bytes", rx_bytes, timestamp
-      output "#{config[:scheme]}.#{iface}.tx_errors", tx_errors, timestamp
-      output "#{config[:scheme]}.#{iface}.rx_errors", rx_errors, timestamp
-      output "#{config[:scheme]}.#{iface}.tx_dropped", tx_dropped, timestamp
-      output "#{config[:scheme]}.#{iface}.rx_dropped", rx_dropped, timestamp
+      output "#{config[:scheme]}.#{current_iface}.tx_packets", tx_pkts, timestamp
+      output "#{config[:scheme]}.#{current_iface}.rx_packets", rx_pkts, timestamp
+      output "#{config[:scheme]}.#{current_iface}.tx_bytes", tx_bytes, timestamp
+      output "#{config[:scheme]}.#{current_iface}.rx_bytes", rx_bytes, timestamp
+      output "#{config[:scheme]}.#{current_iface}.tx_errors", tx_errors, timestamp
+      output "#{config[:scheme]}.#{current_iface}.rx_errors", rx_errors, timestamp
+      output "#{config[:scheme]}.#{current_iface}.tx_dropped", tx_dropped, timestamp
+      output "#{config[:scheme]}.#{current_iface}.rx_dropped", rx_dropped, timestamp
 
     end
     ok


### PR DESCRIPTION
An '--all' flag added to the network metric to allow collection from
all interfaces. Default will collect only from 'eth_' and 'bond_'.
