### PR TITLE
check-raid.sh: remove absolute path to scripts

### DIFF
--- a/sensu/plugins/check-raid.sh
+++ b/sensu/plugins/check-raid.sh
@@ -9,11 +9,11 @@ done
 CRITICALITY=${CRITICALITY:-critical}
 
 if lspci | grep RAID | grep -i 3ware >> /dev/null; then
-    sudo /etc/sensu/plugins/check_3ware_raid.py -b /usr/sbin/tw-cli -z $CRITICALITY
+    sudo check_3ware_raid.py -b /usr/sbin/tw-cli -z $CRITICALITY
 elif lspci | grep RAID | grep -i "MegaRAID" >> /dev/null; then
-    if [[ -e /etc/sensu/plugins/check-storcli.pl && -e /usr/sbin/storcli64 ]];then
-      sudo /etc/sensu/plugins/check-storcli.pl -p /usr/sbin/storcli64 -z $CRITICALITY
+    if [[ -e check-storcli.pl && -e /usr/sbin/storcli64 ]];then
+      sudo check-storcli.pl -p /usr/sbin/storcli64 -z $CRITICALITY
     else
-      sudo /etc/sensu/plugins/check_megaraid_sas.pl -b /usr/sbin/megacli -o 63 -z $CRITICALITY
+      sudo check_megaraid_sas.pl -b /usr/sbin/megacli -o 63 -z $CRITICALITY
     fi
 fi;


### PR DESCRIPTION
As found during the move to apt package of ursula-monitoring installed in `/opt/sensu/plugins`, this script relied on the assumption they were still installed in `/etc/sensu/plugins`. Updates mirroring any `PATH` updates are also being made.
