### PR TITLE
Fix return statements from "ok" to "exit"

### DIFF
--- a/sensu/plugins/load-metrics.rb
+++ b/sensu/plugins/load-metrics.rb
@@ -27,17 +27,17 @@ class LoadStat < Sensu::Plugin::Metric::CLI::Graphite
     timestamp = Time.now.to_i
     metrics = {
       :load_avg => {
-         :one => result[0],
-         :five => result[1],
-         :fifteen => result[2]
-       }
+        :one => result[0],
+        :five => result[1],
+        :fifteen => result[2]
+      }
     }
     metrics.each do |parent, children|
       children.each do |child, value|
         output [config[:scheme], parent, child].join("."), value, timestamp
       end
     end
-    ok
+    exit
   end
 
 end

--- a/sensu/plugins/memory-metrics.rb
+++ b/sensu/plugins/memory-metrics.rb
@@ -13,14 +13,11 @@ class MemoryGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     # Metrics borrowed from hoardd: https://github.com/coredump/hoardd
-
     mem = metrics_hash
-
     mem.each do |k, v|
       output "#{config[:scheme]}.#{k}", v
     end
-
-    ok
+    exit
   end
 
   def metrics_hash
@@ -34,13 +31,11 @@ class MemoryGraphite < Sensu::Plugin::Metric::CLI::Graphite
       mem['swapFree']  = line.split(/\s+/)[1].to_i * 1024 if line.match(/^SwapFree/)
       mem['dirty']     = line.split(/\s+/)[1].to_i * 1024 if line.match(/^Dirty/)
     end
-
     mem['swapUsed'] = mem['swapTotal'] - mem['swapFree']
     mem['used'] = mem['total'] - mem['free']
     mem['usedWOBuffersCaches'] = mem['used'] - (mem['buffers'] + mem['cached'])
     mem['freeWOBuffersCaches'] = mem['free'] + (mem['buffers'] + mem['cached'])
     mem['swapUsedPercentage'] = 100 * mem['swapUsed'] / mem['swapTotal'] if mem['swapTotal'] > 0
-
     mem
   end
 

--- a/sensu/plugins/metrics-net.rb
+++ b/sensu/plugins/metrics-net.rb
@@ -110,8 +110,7 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
       output "#{config[:scheme]}.#{current_iface}.rx_errors", rx_errors, timestamp
       output "#{config[:scheme]}.#{current_iface}.tx_dropped", tx_dropped, timestamp
       output "#{config[:scheme]}.#{current_iface}.rx_dropped", rx_dropped, timestamp
-
     end
-    ok
+    exit
   end
 end

--- a/sensu/plugins/vmstat-metrics.rb
+++ b/sensu/plugins/vmstat-metrics.rb
@@ -42,26 +42,26 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
       :procs => {
          :waiting => result[0],
          :uninterruptible => result[1]
-       },
-       :memory => {
+      },
+      :memory => {
          :swap_used => result[2],
          :free => result[3],
          :buffers => result[4],
          :cache => result[5]
-       },
-       :swap => {
+      },
+      :swap => {
          :in => result[6],
          :out => result[7]
-       },
-       :io => {
+      },
+      :io => {
          :received => result[8],
          :sent => result[9]
-       },
-       :system => {
+      },
+      :system => {
          :interrupts_per_second => result[10],
          :context_switches_per_second => result[11]
-       },
-       :cpu => {
+      },
+      :cpu => {
          :user => result[12],
          :system => result[13],
          :idle => result[14],
@@ -73,7 +73,7 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
         output [config[:scheme], parent, child].join("."), value, timestamp
       end
     end
-    ok
+    exit
   end
 
 end


### PR DESCRIPTION
Not sure this will help, but empty metrics seem to be given as a byproduct of these `for/.each` statements.
