### PR TITLE
Replace keystone client usage w/ openstack client

### DIFF
--- a/sensu/plugins/check-os-api.rb
+++ b/sensu/plugins/check-os-api.rb
@@ -29,7 +29,7 @@ class CheckOSApi < Sensu::Plugin::Check::CLI
     when "glance"
       "glance image-list"
     when "keystone"
-      "keystone endpoint-list"
+      "openstack endpoint list"
     when "heat"
       "heat stack-list"
     when "ceilometer"


### PR DESCRIPTION
With the most recent keystoneclient releases, the `keystone` client is
removed in favor of the `openstack` client. Change this check as such.
