### PR TITLE
Filter server list by host

### DIFF
--- a/sensu/plugins/check-cinder-sessions.py
+++ b/sensu/plugins/check-cinder-sessions.py
@@ -40,7 +40,8 @@ def _get_local_active_instance_volumes():
     local_attached_vols = []
     nova = nova_client(version=2, **CREDS)
     search_opts = {
-        'all_tenants': True
+        'all_tenants': True,
+        'host': hostname,
     }
     for server in nova.servers.list(search_opts=search_opts):
         if getattr(server, "OS-EXT-STS:vm_state") != "active":


### PR DESCRIPTION
check-cinder-sessions doesn't currently push a filter to the server API,
which means that all instances are listed and then filtered in the
querying box, which is every hypervisor. This causes quite a bit of load
as more and more instances are added and more hypervisors are added.
