### PR TITLE
Change the metric-nova-state plug to use the all-tenants flag

### DIFF
--- a/sensu/plugins/metrics-nova-state.py
+++ b/sensu/plugins/metrics-nova-state.py
@@ -27,7 +27,7 @@ def main():
                     project_id=args.tenant, auth_url=args.auth_url,
                     service_type=args.service_type)
 
-    servers = client.servers.list()
+    servers = client.servers.list(search_opts={ 'all_tenants': True })
 
     # http://docs.openstack.org/api/openstack-compute/2/content/List_Servers-d1e2078.html
     states = {


### PR DESCRIPTION
I am proposing changes this plugin to use the all-tenants flag. Currently
this plugin will only list the servers created by the env's OS_USERNAME user. I feel
this plugin is more valuable if we get the states of all the VMs within the
cloud.
