### PR TITLE
increase default rabbit timeout to 3

### DIFF
--- a/sensu/plugins/check-rabbitmq-queues.rb
+++ b/sensu/plugins/check-rabbitmq-queues.rb
@@ -39,7 +39,7 @@ class CheckRabbitCluster < Sensu::Plugin::Check::CLI
           :description => "timeout in seconds when querying rabbit",
           :short => '-m SECONDS',
           :long => '--timeout SECONDS',
-          :default => 1
+          :default => 3
 
   def set_defaults
     if config[:type] == 'length'


### PR DESCRIPTION
Operations have mentioned they often have to set
timeout to 3secs on busy clusters or this alert
creates false alerts.
