### PR TITLE
Alter check-cpu process sort order

### DIFF
--- a/sensu/plugins/check-cpu.rb
+++ b/sensu/plugins/check-cpu.rb
@@ -99,7 +99,7 @@ class CheckCPU < Sensu::Plugin::Check::CLI
   end
 
   def get_top_process_by_cpu_mem
-    `ps axo pcpu,pmem,cmd k pmem,pcpu | tail -n 1`.chomp
+    `ps axo pcpu,pmem,cmd k pcpu,pmem | tail -n 1`.chomp
   end
 
 end


### PR DESCRIPTION
check-cpu will try to determine if the "top" process is one to be
ignored or not. It uses ps to do this, and sorts. Previously it sorted
by percent of memory usage, rather than percent of CPU. This means that
even if numerous CPUs were at 100% usage, when sorted by percent of
memory, often kvm would come to the surface as it consumes way more
memory. This process would get ignored and no alert would go out.

Sorting by CPU usage means it'll be correct more often, but there is
still a gap in the logic here to be worked out, as multiple processes
could have 100% CPU and only one process is being checked.
