### PR TITLE
Instruct metrics-ceph.py to use python env.

### DIFF
--- a/sensu/plugins/metrics-ceph.py
+++ b/sensu/plugins/metrics-ceph.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 


### PR DESCRIPTION
Add missing  "#!/usr/bin/env python" sha-bang
