### PR TITLE
ursula monitoring update for centos

### DIFF
--- a/sensu/plugins/check-cinder-services.sh
+++ b/sensu/plugins/check-cinder-services.sh
@@ -9,7 +9,7 @@ done
 CRITICALITY=${CRITICALITY:-critical}
 
 set -e
-if cinder-manage service list | tail -n +2 | grep XXX; then
+if openstack volume service list | grep "down"; then
   echo "a cinder service is down"
   if [ "$CRITICALITY" == "warning" ]; then
     exit 1

--- a/sensu/plugins/check-cinder-sessions.py
+++ b/sensu/plugins/check-cinder-sessions.py
@@ -19,16 +19,7 @@ import os
 import subprocess
 import sys
 
-from novaclient.client import Client as nova_client
-
-CREDS = {
-    'username': os.environ['OS_USERNAME'],
-    'api_key': os.environ['OS_PASSWORD'],
-    'project_id': os.environ['OS_TENANT_NAME'],
-    'auth_url': os.environ['OS_AUTH_URL'],
-    'region_name': 'RegionOne',
-}
-
+import shade
 
 def _get_hostname():
     return subprocess.check_output(['hostname', '-f']).strip()
@@ -38,7 +29,7 @@ def _get_local_active_instance_volumes():
     hostname = _get_hostname()
 
     local_attached_vols = []
-    nova = nova_client(version=2, **CREDS)
+    nova = shade.openstack_cloud().nova_client
     search_opts = {
         'all_tenants': True,
         'host': hostname,

--- a/sensu/plugins/check-keystone-expired-tokens.py
+++ b/sensu/plugins/check-keystone-expired-tokens.py
@@ -22,7 +22,6 @@ import argparse
 from datetime import datetime
 
 from keystone.cmd import cli
-from keystone.common import environment
 from keystone import token
 from keystone.common import sql
 from keystone.token.persistence.backends.sql import TokenModel
@@ -75,7 +74,6 @@ cli.CMDS.append(TokenList)
 
 
 if __name__ == '__main__':
-    environment.use_stdlib()
 
     dev_conf = os.path.join(possible_topdir,
                             'etc',
@@ -85,9 +83,9 @@ if __name__ == '__main__':
         config_files = [dev_conf]
     
     parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--critical', type=int, default=1000, 
+    parser.add_argument('-c', '--critical', type=int, default=10000, 
 	                    help='Critical value', action='store')
-    parser.add_argument('-w', '--warning', type=int, default=10000, 
+    parser.add_argument('-w', '--warning', type=int, default=1000, 
 	                    help='Warning value', action='store')
     args = vars(parser.parse_args())
 	
@@ -96,3 +94,4 @@ if __name__ == '__main__':
 
     # keystone-manage wants a command as a argv, so give it token_list
     cli.main(argv=[sys.argv[0],'token_list'], config_files=config_files)
+

--- a/sensu/plugins/check-mem.sh
+++ b/sensu/plugins/check-mem.sh
@@ -10,6 +10,9 @@
 # The memory check is done with following command line:
 # free -m | grep buffers/cache | awk '{ print $4 }'
 
+# set lang
+LANG=C
+
 # get arguments
 
 # #RED
@@ -26,7 +29,6 @@ done
 # usage
 HELP="
     usage: $0 [ -w value -c value -p -h ]
-
         -w --> Warning MB < value
         -c --> Critical MB < value
         -p --> print out performance data
@@ -41,7 +43,11 @@ fi
 WARN=${WARN:=0}
 CRIT=${CRIT:=0}
 
-FREE_MEMORY=`free -m | grep buffers/cache | awk '{ print $4 }'`
+set -o pipefail
+FREE_MEMORY=$(free -m | grep buffers/cache | awk '{ print $4 }')
+if [ $? -ne 0 ]; then
+  FREE_MEMORY=$(free -m | grep Mem | awk '{ print $7 }')
+fi
 
 if [ "$FREE_MEMORY" = "" ]; then
   echo "MEM UNKNOWN -"

--- a/sensu/plugins/check-nbd-nonunique.sh
+++ b/sensu/plugins/check-nbd-nonunique.sh
@@ -25,7 +25,12 @@ fi
 
 CRIT=${CRIT:=1}
 
-NO_NBD=`ps h $(pgrep qemu-nbd) | awk '{ print $(NF) }' | uniq -d | wc -l`
+PID_COUNT=`pgrep qemu-nbd | wc -l`
+NO_NBD=0
+
+if (( $PID_COUNT >= 1 )); then
+  NO_NBD=`ps h $(pgrep qemu-nbd) | awk '{ print $(NF) }' | uniq -d | wc -l`
+fi
 
 output="$NO_NBD files open by multiple /dev/nbdX"
 

--- a/sensu/plugins/check-ucarp-procs.sh
+++ b/sensu/plugins/check-ucarp-procs.sh
@@ -8,8 +8,21 @@ done
 
 CRITICALITY=${CRITICALITY:-critical}
 
-for IFACE in $(ifquery --list); do
-  for VIP in $(ifquery ${IFACE} | awk '/^ucarp-vip:/ {print $2}'); do
+if $(which ifquery >/dev/null 2>&1); then  # for ubuntu
+  for IFACE in $(ifquery --list); do
+    for VIP in $(ifquery ${IFACE} | awk '/^ucarp-vip:/ {print $2}'); do
+      if ! ps -ef | grep '/usr/sbin/ucarp' | grep ${VIP} >/dev/null; then
+        echo "no ucarp process is running for IP ${VIP}"
+        if [ "$CRITICALITY" == "warning" ]; then
+          exit 1
+        else
+          exit 2
+        fi
+      fi
+    done
+  done
+else # for centos/rhel
+  for VIP in $(awk '/^[^#]*VIP_ADDRESS/' /etc/ucarp/*.conf | sed 's/.*VIP_ADDRESS="\([^,]*\)"/\1/g'); do
     if ! ps -ef | grep '/usr/sbin/ucarp' | grep ${VIP} >/dev/null; then
       echo "no ucarp process is running for IP ${VIP}"
       if [ "$CRITICALITY" == "warning" ]; then
@@ -19,6 +32,6 @@ for IFACE in $(ifquery --list); do
       fi
     fi
   done
-done
+fi
 
 echo "All interfaces configured with uCARP have running process"

--- a/sensu/plugins/metrics-disk-capacity.rb
+++ b/sensu/plugins/metrics-disk-capacity.rb
@@ -63,7 +63,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
         fs, _type, _blocks, used, avail, capacity, _mnt = line.split
 
         timestamp = Time.now.to_i
-        if fs =~ '/dev'
+        if fs =~ /\/dev/
           fs = fs.gsub('/dev/', '')
           metrics = {
             disk: {
@@ -89,7 +89,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
         fs, _inodes, used, avail, capacity, _mnt = line.split
 
         timestamp = Time.now.to_i
-        if fs =~ '/dev'
+        if fs =~ /\/dev/
           fs = fs.gsub('/dev/', '')
           metrics = {
             disk: {

--- a/sensu/plugins/metrics-nova-state.py
+++ b/sensu/plugins/metrics-nova-state.py
@@ -6,7 +6,7 @@ import socket
 import time
 import os
 
-from novaclient.client import Client
+import shade
 
 DEFAULT_SCHEME = '{}.nova.states'.format(socket.gethostname())
 
@@ -15,19 +15,13 @@ def output_metric(name, value):
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument('-u', '--user', default=os.environ['OS_USERNAME'])
-    parser.add_argument('-p', '--password', default=os.environ['OS_PASSWORD'])
-    parser.add_argument('-t', '--tenant', default=os.environ['OS_TENANT_NAME'])
-    parser.add_argument('-a', '--auth-url', default=os.environ['OS_AUTH_URL'])
     parser.add_argument('-S', '--service-type', default='compute')
     parser.add_argument('-s', '--scheme', default=DEFAULT_SCHEME)
     args = parser.parse_args()
 
-    client = Client(version=2, username=args.user, api_key=args.password,
-                    project_id=args.tenant, auth_url=args.auth_url,
-                    service_type=args.service_type)
+    cloud = shade.openstack_cloud()
 
-    servers = client.servers.list(search_opts={ 'all_tenants': True })
+    servers = cloud.nova_client.servers.list(search_opts={ 'all_tenants': True })
 
     # http://docs.openstack.org/api/openstack-compute/2/content/List_Servers-d1e2078.html
     states = {

--- a/sensu/plugins/metrics-nova.py
+++ b/sensu/plugins/metrics-nova.py
@@ -11,7 +11,7 @@ import socket
 import time
 import os
 
-from novaclient.client import Client
+import shade
 
 DEFAULT_SCHEME = '{}.nova.hypervisors'.format(socket.gethostname())
 
@@ -32,25 +32,16 @@ def output_metric(name, value):
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument('-u', '--user', default=os.environ['OS_USERNAME'])
-    parser.add_argument('-p', '--password', default=os.environ['OS_PASSWORD'])
-    parser.add_argument('-t', '--tenant', default=os.environ['OS_TENANT_NAME'])
-    parser.add_argument('-a', '--auth-url', default=os.environ['OS_AUTH_URL'])
-    parser.add_argument('-S', '--service-type', default='compute')
     parser.add_argument('-H', '--host')
     parser.add_argument('-s', '--scheme', default=DEFAULT_SCHEME)
     args = parser.parse_args()
 
-    args.user
-
-    client = Client(version=2, username=args.user, api_key=args.password,
-                    project_id=args.tenant, auth_url=args.auth_url,
-                    service_type=args.service_type)
-
+    cloud = shade.openstack_cloud()
+	
     if args.host:
-        hypervisors = client.hypervisors.search(args.host)
+        hypervisors = cloud.nova_client.hypervisors.search(args.host)
     else:
-        hypervisors = client.hypervisors.list()
+        hypervisors = cloud.nova_client.hypervisors.list()
 
     for hv in hypervisors:
         hostname = hv.hypervisor_hostname.split('.')[0]

--- a/sensu/plugins/metrics-os-api.py
+++ b/sensu/plugins/metrics-os-api.py
@@ -200,7 +200,7 @@ def main():
                'X-Auth-Token': token}
 
     urls = {
-        'keystone':('keystone', 'keystone' , '/tenants'),
+        'keystone':('keystone', 'keystone' , '/v2.0/tenants'),
         'nova':('nova', 'nova' , '/servers/detail'),
         'neutron':('neutron', 'neutron' ,
         '/v2.0/networks?tenant_id=%s' % tenant_id),


### PR DESCRIPTION
related change works both for centos-newton and ubuntu-mitaka.
1. novaclient old version support parameter project_id, new version change to project_name.
solution: import shade, which works for both version. (Cloud configs are read with os-client-config)
http://docs.openstack.org/infra/shade/
it's used in other metrics plugs in too.

2. ImportError: cannot import name environment for keystone token expiration check.
new version of keystone has no environment directory anymore.
solution: remove environement, and it has no impact to both old ubuntu cloud and new centos cloud

3. check-mem.sh not work for centos, since the free -m output is different.
solution: get the latest version of sensu-plugin community version, and works

4. check-nbd-nonunique.sh not work well both for unbuntu and centos.
The purpose of this check is for qemu-nbd related process only, but existing shell didn't consider situation of no qemu-nbd related process exist.

5. metrics-disk-capacity, use the community version to correct rhel related issue.

6. metrics-os-api keystone url incorrect, 404 not found