### PR TITLE
fix project limits metrics and check-raid

### DIFF
--- a/sensu/plugins/check-raid.sh
+++ b/sensu/plugins/check-raid.sh
@@ -11,7 +11,7 @@ CRITICALITY=${CRITICALITY:-critical}
 if lspci | grep RAID | grep -i 3ware >> /dev/null; then
     sudo check_3ware_raid.py -b /usr/sbin/tw-cli -z $CRITICALITY
 elif lspci | grep RAID | grep -i "MegaRAID" >> /dev/null; then
-    if [[ -e check-storcli.pl && -e /opt/MegaRAID/storcli/storcli64 ]];then
+    if [[ -e /etc/sensu/plugins/check-storcli.pl && -e /opt/MegaRAID/storcli/storcli64 ]];then
       sudo check-storcli.pl -p /opt/MegaRAID/storcli/storcli64 -Io 63 -z $CRITICALITY
     else
       sudo check_megaraid_sas.pl -b /usr/sbin/megacli -o 63 -z $CRITICALITY

--- a/sensu/plugins/metrics-openstack-project-limits.py
+++ b/sensu/plugins/metrics-openstack-project-limits.py
@@ -25,10 +25,10 @@ class CloudMetrics(object):
 
     def get_limits(self, service_type):
         if service_type == "nova":
-            return ([self.cloud.nova_client.limits.get(project['id'])._info.copy(),project['name']]
+            return ([self.cloud.nova_client.limits.get(tenant_id=project['id'])._info.copy(),project['name']]
                 for project in self.cloud.list_projects())
         if service_type == "cinder":
-            return ([self.cloud.cinder_client.limits.get(project['id'])._info.copy(),project['name']]
+            return ([self.cloud.cinder_client.limits.get(tenant_id=project['id'])._info.copy(),project['name']]
                 for project in self.cloud.list_projects())
 
     def graphite_print(self, limits, service_type):


### PR DESCRIPTION
1. project limits metrics fix:
When I create grafana dashboard based on the metrics ouput,  I found
this defect that all project's limits and usages were same.
After the fix,  projects have correct limits and usage.

2. check-raid metrics fix:
before the fix, the check output as : error: /usr/sbin/megacli does not exist.