### PR TITLE
remove-useless-warning

### DIFF
--- a/sensu/plugins/check-storcli.pl
+++ b/sensu/plugins/check-storcli.pl
@@ -1162,7 +1162,7 @@ MAIN: {
   my $platform = $^O;
 
   # Check storcli tool
-  $storcli = `which storcli64`;
+  $storcli = `which storcli64 2>/dev/null`;
   chomp($storcli);
   
   if( !(GetOptions(


### PR DESCRIPTION
remove msg like "/usr/bin/which: no storcli64 in xxxx" to make check
output more clean.