### PR TITLE
Add aodh api service check

### DIFF
--- a/sensu/plugins/check-os-api.rb
+++ b/sensu/plugins/check-os-api.rb
@@ -36,6 +36,8 @@ class CheckOSApi < Sensu::Plugin::Check::CLI
       "ceilometer meter-list -l 1"
     when "barbican"
       "openstack secret list -l 1"
+    when "aodh"
+      "ceilometer alarm-list"
     end
   end
 


### PR DESCRIPTION
add missing aodh api status check.
The reason of not adding for cinder/neutron is : there are many other cinder/neutron service status check already exists.