### PR TITLE
To fix check error when command output has characters other than ascii

### DIFF
--- a/sensu/plugins/check-os-api.rb
+++ b/sensu/plugins/check-os-api.rb
@@ -40,7 +40,7 @@ class CheckOSApi < Sensu::Plugin::Check::CLI
   end
 
   def run
-    system("#{safe_command}")
+    system("#{safe_command}" + " > /dev/null ")
 
     if $?.exitstatus == 0
       exit


### PR DESCRIPTION
To resolve error like below:
‘ascii' codec can't encode characters in position 323-324: ordinal not
in range(128)