### PR TITLE
changing loglevel on inspec check

### DIFF
--- a/sensu/plugins/check-inspec.rb
+++ b/sensu/plugins/check-inspec.rb
@@ -52,7 +52,7 @@ class CheckInspec < Sensu::Plugin::Check::CLI
          default: 'critical'
 
   def inspec(controls, attrs)
-    inspec = `inspec exec #{controls} --attrs #{attrs} --format=json-min`
+    inspec = `inspec exec #{controls} --attrs #{attrs} --format=json-min --log-level=error`
     JSON.parse(inspec)
   end
 


### PR DESCRIPTION
Adjusting log level for the inspec check to supress gem warnings which cause malformed json.