### PR TITLE
check-cert-expiry

### DIFF
--- a/sensu/plugins/check-cert-expiry_README
+++ b/sensu/plugins/check-cert-expiry_README
@@ -1,0 +1,1 @@
+https://github.ibm.com/bluebox/check-cert-expiry


### PR DESCRIPTION
A standalone binary check written in golang
checks for openssl cert expiration
https://github.ibm.com/bluebox/check-cert-expiry