### PR TITLE
added Dockerfile and documented build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:trusty
+RUN apt-get update -yy && \
+    apt-get install -yy ruby ruby-dev build-essential git && \
+    git clone https://github.com/jordansissel/fpm.git && \
+    cd fpm && gem install --no-ri --no-rdoc fpm
+WORKDIR /ursula-monitoring
+CMD make

--- a/README.md
+++ b/README.md
@@ -1,23 +1,65 @@
 # ursula-monitoring
 
-Monitoring and Logging modules and tools used by Ursula
+This repo contains monitoring and logging modules used by Ursula and Site Controller.
 
-## Sensu
 
-All files in `sensu/plugins` should have executable bit set.
+## Updates and tags
 
-## Building packages
+Place updated sensu plugin scripts into the `sensu/plugins/` directory, ensuring the files have the executable bit set.
 
-Package version numbers are derived from annotated tags with `git describe`.
+After committing your updates, create an annotated tag using the next available version number.  The latest tag will be used as the version number when building either a DEB package or downloading the tarball.
 
-General build procedure:
+To create a new annotated tag:
+```
+git tag -a 'X.Y.Z' -m'version X.Y.Z'
+```
 
-1. Use `git checkout` to point HEAD to desired commit.
-2. Use `git tag -a 'vX.Y.Z' -m'version X.Y.Z'` to create an annotated tag at that commit.
-3. To build packages, call `make`.
+
+## Deployment
+
+You can deploy to Ursula from a tarball, and to Site Controller from a Debian package.
+
+
+### Tarball deployment
+
+Select the tagged version you want, and download the tar.gz file.  This can be uploaded to your file mirror as needed for deployment.
+
+
+### Package deployment
+
+To deploy from a debian package, you build the package, and upload to the repo(s) used by your system.
+
+
+#### Docker package build
+
+
+First you need to build a local docker image named `ursula-monitoring`.  You'll use this in the next step to build the DEB package.  Make sure you have the desired annotated tag checked out, as this is how the package version number will be set.
+
+```
+cd ursula-monitoring/
+docker build -t ursula-monitoring .
+```
+
+Now you just run this command, which builds the package within the container and makes it available under the `build/` subdirectory.
+```
+docker run -v $PWD:/ursula-monitoring ursula-monitoring
+```
+
+As stated above, the new debian package file is in the `build/` directory.  You can upload that to the mirrors used by your system to deploy.
+
+
+#### Manual package build
+
+If you'd like to build the package outside of docker, you can. However, the system requires [fpm](https://github.com/jordansissel/fpm) to build packages and the [package_cloud](https://rubygems.org/gems/package_cloud) gem to upload to packagecloud.io.
+
+1. Checkout desired version.
+   Use `git checkout` to point HEAD to desired commit.
+2. Ensure desired tag (package version).
+   If you need to create a new annotated tag, use `git tag -a 'X.Y.Z' -m'version X.Y.Z'`.
+3. To build the package, call `make`.
 4. To upload to packagecloud.io, `make upload PACKAGECLOUD_REPO=username/repo` (or set `PACKAGECLOUD_REPO` in your environment).
 
-Requires [fpm](https://github.com/jordansissel/fpm) to build packages and the [package_cloud](https://rubygems.org/gems/package_cloud) gem to upload to packagecloud.io.
+
 
 ## License
 


### PR DESCRIPTION
Building from docker is easier and requires less setup.  In addition to writing the Dockerfile, I expanded the documentation and filled in missing details.